### PR TITLE
add workspace setting for JAVA_HOME

### DIFF
--- a/package.json
+++ b/package.json
@@ -240,6 +240,13 @@
           "markdownDescription": "Optional path to a directory with rules of a word2vec language model.",
           "description": "Optional path to a directory with rules of a word2vec language model."
         },
+        "ltex.javaHome": {
+          "type": "string",
+          "scope": "window",
+          "default": "",
+          "markdownDescription": "Override the path to the java installation used to run LanguageTool.",
+          "description": "Override the path to the java installation used to run LanguageTool."
+        },
         "ltex.performance.initialJavaHeapSize": {
           "type": "integer",
           "scope": "window",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,6 +104,9 @@ export function activate(context: ExtensionContext) {
         const maximumJavaHeapSize: number = workspaceConfig['performance']['maximumJavaHeapSize'];
         environmentVariables["LANGUAGETOOL_LANGUAGESERVER_OPTS"] =
             "-Xms" + initialJavaHeapSize + "m -Xmx" + maximumJavaHeapSize +"m";
+        if(workspaceConfig.has('javaHome')){
+          environmentVariables["JAVA_HOME"] =  workspaceConfig['javaHome'];
+        } 
         const childProcess: child_process.ChildProcess = child_process.spawn(
             newScript, [server.address().port.toString()], {"env": environmentVariables});
 


### PR DESCRIPTION
Thank you for creating this nice extension. I am often working with a portable installation of VSCode and Java without having control over environment variables. An additional setting for JAVA_HOME greatly improved my workflow. Would be nice if you would accept this PR.