### PR TITLE
Replace \ref{} with \label{} in example for ltex.latex.commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1660,7 +1660,7 @@
           "markdownDescription": "%ltex.i18n.configuration.ltex.latex.commands.markdownDescription%",
           "examples": [
             {
-              "\\ref{}": "ignore",
+              "\\ref{}": "dummy",
               "\\documentclass[]{}": "ignore",
               "\\cite{}": "dummy",
               "\\cite[]{}": "dummy"

--- a/package.json
+++ b/package.json
@@ -1660,7 +1660,7 @@
           "markdownDescription": "%ltex.i18n.configuration.ltex.latex.commands.markdownDescription%",
           "examples": [
             {
-              "\\ref{}": "dummy",
+              "\\label{}": "ignore",
               "\\documentclass[]{}": "ignore",
               "\\cite{}": "dummy",
               "\\cite[]{}": "dummy"


### PR DESCRIPTION
## Description

Replaced
```
"ltex.latex.commands": {
    "\\ref{}": "ignore"
},
```
by 
```
"ltex.latex.commands": {
    "\\ref{}": "dummy"
},
```
in `package.json`.

`"ignore"` gives a warning (`Don't put a space before the full stop. – COMMA_PARENTHESIS_WHITESPACE`), e.g., in the sentence `See section~\ref{test}.`


`ltex-ls` seems to have this correctly set to `"dummy"`:
https://github.com/valentjn/ltex-ls/blob/6315cb6cb2c3583618ceb031c4312a5d54b7ab59/src/main/java/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderDefaults.java#L509

