### PR TITLE
Add R Markdown support

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "onLanguage:latex",
     "onLanguage:markdown",
     "onLanguage:org",
+    "onLanguage:rmd",
     "onLanguage:restructuredtext",
     "onLanguage:rsweave",
     "onNotebook:*"
@@ -159,6 +160,7 @@
             "latex",
             "markdown",
             "org",
+            "rmd",
             "restructuredtext",
             "rsweave"
           ],

--- a/src/CommandHandler.ts
+++ b/src/CommandHandler.ts
@@ -61,6 +61,7 @@ export default class CommandHandler {
     'org',
     'restructuredtext',
     'rsweave',
+    'rmd',
   ];
 
   public constructor(context: Code.ExtensionContext, externalFileManager: ExternalFileManager,
@@ -449,6 +450,11 @@ export default class CommandHandler {
         }
         case 'restructuredtext': {
           enabledFileExtensions.add('rst');
+          break;
+        }
+        case 'rmd': {
+          enabledFileExtensions.add('rmd');
+          enabledFileExtensions.add('Rmd');
           break;
         }
         case 'rsweave': {


### PR DESCRIPTION
## Description

Adds `vscode-ltex` start up on `.Rmd` or `rmd` files viewing.

Linked to https://github.com/valentjn/ltex-ls/pull/170#issue-1276609881
(Server side R Markdown support) 

## Checklist

* [x] Have you read the [guidelines on contributing code to LT<sub>E</sub>X](https://valentjn.github.io/ltex/vscode-ltex/contributing.html#how-to-contribute-code)?
* [x] Have you filled in all missing information in this pull request template?
* [ ] Have you written new tests for your changes, if applicable?
* [x] Do your changes pass all [code checks](https://valentjn.github.io/ltex/vscode-ltex/contributing.html#code-checks) such as linting and tests?
